### PR TITLE
Add responsive events page

### DIFF
--- a/events.html
+++ b/events.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Babylon Village Events</title>
+<style>
+  body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f7f6ff;
+    color: #333;
+  }
+  header {
+    background: #bce0d8;
+    padding: 1rem;
+    text-align: center;
+  }
+  header h1 {
+    margin: 0;
+    color: #333;
+  }
+  .container {
+    max-width: 800px;
+    margin: auto;
+    padding: 1rem;
+  }
+  .event {
+    background: #ffffff;
+    border-radius: 8px;
+    padding: 1rem;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    margin-bottom: 1rem;
+  }
+  .event h3 {
+    margin: 0 0 0.5rem 0;
+    color: #6d7993;
+  }
+  .event time,
+  .event .place {
+    display: block;
+    color: #555;
+  }
+  @media (max-width: 600px) {
+    body {
+      padding: 0;
+    }
+    .container {
+      padding: 0.5rem;
+    }
+  }
+</style>
+</head>
+<body>
+<header>
+  <h1>Upcoming Events</h1>
+</header>
+<div class="container" id="events"></div>
+<script>
+async function loadEvents() {
+  try {
+    const res = await fetch('events.json');
+    const events = await res.json();
+    const container = document.getElementById('events');
+    events.forEach(ev => {
+      const div = document.createElement('div');
+      div.className = 'event';
+      const date = ev.Date ? new Date(ev.Date) : null;
+      const dateStr = date ? date.toLocaleString(undefined, {dateStyle: 'medium', timeStyle: 'short'}) : 'TBA';
+      div.innerHTML = `<h3>${ev.Name}</h3><time>${dateStr}</time><span class="place">${ev.Place}</span>`;
+      container.appendChild(div);
+    });
+  } catch (e) {
+    document.getElementById('events').textContent = 'Failed to load events.';
+  }
+}
+loadEvents();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple responsive HTML page to view events

## Testing
- `bash test.sh` *(fails: `deno: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687b26d84e4c832f9ec8bdba8c45ddd7