### PR TITLE
Fix date parsing tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+## Instructions for Codex
+
+- Before running tests, ensure Deno is installed. Install using:
+  ```bash
+  curl -fsSL https://deno.land/install.sh | sh
+  export DENO_INSTALL="/root/.deno"
+  export PATH="$DENO_INSTALL/bin:$PATH"
+  ```
+- Run tests with:
+  ```bash
+  DENO_TLS_CA_STORE=system ./test.sh
+  ```
+

--- a/event/eventParser.test.ts
+++ b/event/eventParser.test.ts
@@ -26,9 +26,10 @@ describe('eventParser.parse', () => {
   });
 
   it('parses the event date correctly', () => {
-    assertEquals(events[0].Date, new Date('2022-12-04 16:00:00 GMT-0500'));
-    assertEquals(events[1].Date, new Date('2022-12-13 20:00:00 GMT-0500'));
-    assertEquals(events[2].Date, new Date('2022-12-15 19:30:00 GMT-0500'));
+    const currentYear = new Date().getFullYear();
+    assertEquals(events[0].Date, new Date(`DEC 4 ${currentYear} 16:00:00 GMT-0500`));
+    assertEquals(events[1].Date, new Date(`DEC 13 ${currentYear} 20:00:00 GMT-0500`));
+    assertEquals(events[2].Date, new Date(`DEC 15 ${currentYear} 19:30:00 GMT-0500`));
   });
 
   it('parses the event place correctly', () => {
@@ -37,3 +38,4 @@ describe('eventParser.parse', () => {
     assertEquals(events[2].Place, 'Village Hall');
   });
 })
+

--- a/event/eventParser.ts
+++ b/event/eventParser.ts
@@ -44,7 +44,7 @@ export default class EventParser {
 
     const dateString = `${monthAbbreviation} ${dayNumber} ${new Date().getFullYear()}`;
 
-    const date = new Date(`${dateString} ${timeString}`);
+    const date = new Date(`${dateString} ${timeString} GMT-0500`);
     return date;
   }
 
@@ -58,3 +58,4 @@ export default class EventParser {
       .join(' ');
   }
 }
+


### PR DESCRIPTION
## Summary
- parse events with GMT-0500 timezone
- expect dates to use the current year in tests
- document how to install Deno and run the tests

## Testing
- `DENO_TLS_CA_STORE=system ./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_687b2abab258832f92aea72960a213f8