### PR TITLE
Fix event date parsing for times without space before am/pm

### DIFF
--- a/event/eventParser.test.ts
+++ b/event/eventParser.test.ts
@@ -37,5 +37,23 @@ describe('eventParser.parse', () => {
     assertEquals(events[1].Place, 'Village Hall');
     assertEquals(events[2].Place, 'Village Hall');
   });
+
+  it('parses times without space before am/pm', () => {
+    const html = `
+      <ul id="CalendarModal">
+        <li class="list-group-item">
+          <div class="calendar-list">
+            <span class="month bg-cyan-p">JUL</span>
+            <span class="day">18</span>
+          </div>
+          Concert<br />
+          8pm Friday Gazebo
+        </li>
+      </ul>`;
+    const doc = new DOMParser().parseFromString(html, 'text/html')!;
+    const result = new EventParser().parse(doc);
+    const currentYear = new Date().getFullYear();
+    assertEquals(result[0].Date, new Date(`JUL 18 ${currentYear} 20:00:00 GMT-0500`));
+  });
 })
 

--- a/event/eventParser.ts
+++ b/event/eventParser.ts
@@ -35,11 +35,16 @@ export default class EventParser {
     const dayNumber = eventTextTokens[1];
     const timeAndPlaceString = eventTextTokens[4];
 
-    let timeNumber = timeAndPlaceString.split(' ')[0];
-    if(timeNumber.indexOf(':') < 0) {
+    const timeMatch = timeAndPlaceString.trim().match(/^(\d{1,2}(?::\d{2})?)\s*([AaPp][Mm])/);
+    if (!timeMatch) {
+      return new Date(NaN);
+    }
+
+    let timeNumber = timeMatch[1];
+    if (timeNumber.indexOf(':') < 0) {
       timeNumber += ':00';
     }
-    const timeAmOrPm = timeAndPlaceString.split(' ')[1];
+    const timeAmOrPm = timeMatch[2].toUpperCase();
     const timeString = `${timeNumber} ${timeAmOrPm}`;
 
     const dateString = `${monthAbbreviation} ${dayNumber} ${new Date().getFullYear()}`;


### PR DESCRIPTION
## Summary
- handle times like `8pm` where am/pm is attached to the number
- add regression test for compact time format

## Testing
- `DENO_TLS_CA_STORE=system ./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_687b325ad458832f878bf22b29c186ef